### PR TITLE
Add command-line option to control web scraping updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,19 @@
+import argparse
 from dashboard import create_app
 
-app = create_app()
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description='ParkRun Dashboard - Display your ParkRun results'
+    )
+    parser.add_argument(
+        '--update',
+        action='store_true',
+        help='Fetch fresh data from ParkRun website before starting dashboard'
+    )
+    return parser.parse_args()
 
 if __name__ == '__main__':
+    args = parse_args()
+    app = create_app(auto_update=args.update)
     app.run(debug=True)

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,7 +1,13 @@
 from flask import Flask
 import os
 
-def create_app():
+def create_app(auto_update=False):
+    """
+    Create and configure the Flask application.
+
+    Args:
+        auto_update: If True, fetch fresh data from ParkRun on startup
+    """
     # Get the parent directory (project root)
     basedir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -9,6 +15,9 @@ def create_app():
     app = Flask(__name__,
                 template_folder=os.path.join(basedir, 'templates'),
                 static_folder=os.path.join(basedir, 'static'))
+
+    # Store auto_update setting in Flask config
+    app.config['AUTO_UPDATE'] = auto_update
 
     from dashboard import routes
     app.register_blueprint(routes.bp)

--- a/dashboard/routes.py
+++ b/dashboard/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, request
+from flask import Blueprint, render_template, request, current_app
 from dashboard.data_loader import load_parkrun_data, get_athlete_info
 from dashboard.charts import create_results_chart
 
@@ -6,9 +6,14 @@ bp = Blueprint('main', __name__)
 
 @bp.route('/')
 def index():
-    # Check if auto-update should be disabled (e.g., ?no_update=1)
-    no_update = request.args.get('no_update', '0') == '1'
-    auto_update = not no_update
+    # Default to command-line setting
+    auto_update = current_app.config.get('AUTO_UPDATE', False)
+
+    # Allow URL parameter to override (e.g., ?no_update=1 or ?update=1)
+    if request.args.get('no_update') == '1':
+        auto_update = False
+    elif request.args.get('update') == '1':
+        auto_update = True
 
     # Load ParkRun data (optionally fetching latest from web)
     df = load_parkrun_data(auto_update=auto_update)


### PR DESCRIPTION
## Summary
- Implements CLI argument parsing with `--update` flag to control when data is fetched from ParkRun website
- Default behavior now uses cached data from `data/results.csv` to prevent unnecessary web requests
- Maintains backward compatibility with URL parameters (`?no_update=1` or `?update=1`)

## Changes
- Added argparse to `app.py` with `--update` flag
- Modified `create_app()` to accept and store `auto_update` setting in Flask config
- Updated `routes.py` to use config setting as default while allowing URL parameter overrides

## Usage
- **Default**: `python app.py` - Uses cached data, no web scraping
- **Update**: `python app.py --update` - Fetches fresh data from ParkRun website

## Test plan
- [x] Verify `--help` displays correct usage information
- [x] Test Flask config correctly stores auto_update setting
- [ ] Run `python app.py` and verify no web requests are made
- [ ] Run `python app.py --update` and verify data is fetched from web

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)